### PR TITLE
Add response event

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,9 +134,7 @@ module.exports = class ServeDrive extends ReadyResource {
     }
 
     rs.pipe(res, safetyCatch)
-    rs.on('close', () => {
-      this.emit('response', id)
-    })
+    rs.on('close', () => this.emit('response', id))
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -134,6 +134,9 @@ module.exports = class ServeDrive extends ReadyResource {
     }
 
     rs.pipe(res, safetyCatch)
+    rs.on('close', () => {
+      this.emit('response', id)
+    })
   }
 }
 

--- a/test/all.js
+++ b/test/all.js
@@ -125,3 +125,42 @@ test('multiple drives', async t => {
   t.is(d.status, 404)
   t.is(d.data, 'DRIVE_NOT_FOUND')
 })
+
+test('emits response event on finishing request (hyperdrive)', async t => {
+  t.plan(3)
+
+  const drive = tmpHyperdrive(t)
+  await drive.put('Something', 'Here')
+  const hexKey = drive.key.toString('hex')
+
+  const serve = tmpServe(t)
+  serve.add(drive, { alias: hexKey })
+  await serve.ready()
+
+  serve.on('response', (id) => {
+    t.is(id, hexKey)
+  })
+
+  const res = await request(serve, `/Something?drive=${hexKey}`)
+  t.is(res.status, 200)
+  t.is(res.data, 'Here')
+})
+
+test('emits response event on finishing request (localdrive)', async t => {
+  t.plan(3)
+
+  const drive = tmpLocaldrive(t)
+  await drive.put('Something', 'Here')
+
+  const serve = tmpServe(t)
+  serve.add(drive, { alias: 'drive' })
+  await serve.ready()
+
+  serve.on('response', (id) => {
+    t.is(id, 'drive')
+  })
+
+  const res = await request(serve, '/Something?drive=drive')
+  t.is(res.status, 200)
+  t.is(res.data, 'Here')
+})


### PR DESCRIPTION
Emits an event when a download ends, useful for example in a scenario with many hyperdrives where you want to dynamically add and remove drives (a drive can be removed when all downloads on it are finished)