### PR TITLE
Reflect hyperdrive's new future-checkout behaviour in test

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -59,11 +59,14 @@ test('checkout query param (hyperdrive)', async t => {
   t.is(oldResp.status, 200)
   t.is(oldResp.data, 'Here')
 
-  const futureResp = await axios.get(
-    `http://localhost:${serve.address().port}/Something?checkout=100`, { validateStatus: null }
+  // Hangs until future version found
+  await t.exception(
+    axios.get(
+      `http://localhost:${serve.address().port}/Something?checkout=100`,
+      { timeout: 200 }
+    ),
+    /timeout/
   )
-  t.is(futureResp.status, 404)
-  t.is(futureResp.data, 'SNAPSHOT_NOT_AVAILABLE')
 })
 
 test('checkout query param ignored for local drive', async t => {


### PR DESCRIPTION
Hyperbee PR https://github.com/holepunchto/hyperbee/pull/97 changed the behaviour of future checkouts for hyperdrives: they no longer throw a not-found exception, but instead wait until the version becomes available. This means the behaviour of serve-drive also changed: it no longer returns 404 on an unavailable version, but hangs forever (or until the request times out).

This PR updates the tests to reflect this behaviour (tests are currently failing with the latest dependencies)