### PR TITLE
(WIP) Catch _driveToRequest errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports = class ServeDrive extends ReadyResource {
 
       rs = snapshot.createReadStream(filename, { start: 0, length: entry.value.blob.byteLength })
     }
-
+    res.on('close', () => rs.destroy())
     await pipelinePromise(rs, res)
   }
 

--- a/index.js
+++ b/index.js
@@ -122,7 +122,6 @@ module.exports = class ServeDrive extends ReadyResource {
 
       rs = snapshot.createReadStream(filename, { start: 0, length: entry.value.blob.byteLength })
     }
-    res.on('close', () => rs.destroy())
     await pipelinePromise(rs, res)
   }
 
@@ -140,6 +139,8 @@ module.exports = class ServeDrive extends ReadyResource {
 
     try {
       await this._driveToRequest(drive, req, res, pathname, id, version)
+    } catch (e) {
+      safetyCatch(e)
     } finally {
       await this.releaseDrive(id)
     }


### PR DESCRIPTION
Note: not sure this is the correct solution. But with the current code, Node crashes if a request ends prematurely because of 

`    await pipelinePromise(rs, res)`

Given that this is a server, I think it should be robust to errors, but just swallowing them might hide bugs. Perhaps we could catch everything and then do `emit('error', e)`, so the caller can decide what to do?

Error trace:

```
Error: Premature close
    at Object.<anonymous> (/home/hans/holepunch/keet-hyperchat-experiment/node_modules/streamx/index.js:3:25)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
    at Module.load (node:internal/modules/cjs/loader:1037:32)
    at Module._load (node:internal/modules/cjs/loader:878:12)
    at Module.require (node:internal/modules/cjs/loader:1061:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/home/hans/holepunch/keet-hyperchat-experiment/node_modules/udx-native/lib/stream.js:1:17)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)
```