### PR TITLE
Rm snapshot.close() for now

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,8 @@ module.exports = class ServeDrive extends ReadyResource {
     }
 
     const snapshot = version ? drive.checkout(version) : drive
-    if (version) req.on('close', () => snapshot.close().catch(safetyCatch))
+    // TODO: add back if session-closed issues cleared up
+    // if (version) req.on('close', () => snapshot.close().catch(safetyCatch))
 
     const filename = decodeURI(pathname)
 


### PR DESCRIPTION
Running into issues downstream. Haven't debugged in detail, but it seems like some resources of the original drive are also closed--might be a Hyperdrive bug

Commenting out unblocks for now