### PR TITLE
(WIP) Emit request-error + fix catch-flow

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,9 +143,9 @@ module.exports = class ServeDrive extends ReadyResource {
     const { pathname, searchParams } = new URL(req.url, 'http://localhost')
     const version = searchParams.get('checkout')
     const id = searchParams.get('drive') // String or null
+    const filename = decodeURI(pathname)
 
     try {
-      const filename = decodeURI(pathname)
       const drive = await this.getDrive(id, filename)
       await this._driveToRequest(drive, req, res, filename, id, version)
     } catch (e) {

--- a/test/all.js
+++ b/test/all.js
@@ -47,6 +47,35 @@ test('getDrive passes cleaned up path', async t => {
   t.is(passedPath, '/Something spacy')
 })
 
+test('emits request-error if unexpected error when getting entry', async t => {
+  const drive = tmpHyperdrive(t)
+  await drive.close() // Will cause errors
+
+  const getDrive = () => drive
+  const serve = tmpServe(t, getDrive)
+
+  let errorObj
+  serve.on('request-error', e => { errorObj = e })
+  await serve.ready()
+
+  const res = await request(serve, 'Whatever')
+  t.is(res.status, 500)
+  t.is(errorObj.code, 'SESSION_CLOSED')
+})
+
+test('emits request-error if unexpected error', async t => {
+  const getDrive = () => { throw new Error('Problem') }
+  const serve = tmpServe(t, getDrive)
+
+  let errorObj
+  serve.on('request-error', e => { errorObj = e })
+  await serve.ready()
+
+  const res = await request(serve, 'Whatever')
+  t.is(res.status, 500)
+  t.is(errorObj.message, 'Problem')
+})
+
 test('404 if file not found', async t => {
   t.plan(2 * 3)
 


### PR DESCRIPTION
Emit 'request-error' event on unexpected error, to facilitate debugging/logging
Also includes a bugfix: my previous PR which added the catch was not ending the connection, now it sends a 500 code


Not sure on the proper flow if `const drive = await this.getDrive(id, filename)` errors out. Currenty it's within the try-catch, but that might mess up the `releaseDrive` logic, because it will still always call `releaseDrive'. Any thoughts?

