### PR TITLE
Norm paths in getLink

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const mime = require('mime-types')
 const ReadyResource = require('ready-resource')
 const safetyCatch = require('safety-catch')
 const { pipelinePromise } = require('streamx')
+const unixPathResolve = require('unix-path-resolve')
 
 module.exports = class ServeDrive extends ReadyResource {
   constructor (opts = {}) {
@@ -48,9 +49,10 @@ module.exports = class ServeDrive extends ReadyResource {
   }
 
   getLink (path, id, version) {
+    path = unixPathResolve('/', path)
     const { port } = this.address()
 
-    let link = `http://localhost:${port}/${path}`
+    let link = `http://localhost:${port}${path}`
     if (id || version) link += '?'
     if (id) link += `drive=${id}`
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ready-resource": "^1.0.0",
     "safety-catch": "^1.0.2",
     "streamx": "^2.13.2",
+    "unix-path-resolve": "^1.0.2",
     "z32": "^1.0.0"
   }
 }

--- a/test/all.js
+++ b/test/all.js
@@ -47,6 +47,32 @@ test('getDrive passes cleaned up path', async t => {
   t.is(passedPath, '/Something spacy')
 })
 
+test('getLink handles different path formats', async t => {
+  const serve = tmpServe(t, () => {})
+  await serve.ready()
+  const link1 = serve.getLink('myFile')
+  const link2 = serve.getLink('/myFile')
+  const link3 = serve.getLink('./myFile')
+
+  const base = `http://localhost:${serve.address().port}`
+  t.is(link1, link2)
+  t.is(link1, link3)
+  t.is(link1, `${base}/myFile`)
+
+  const link4 = serve.getLink('/myDir/myFile.txt')
+  t.is(link4, `${base}/myDir/myFile.txt`)
+})
+
+test('getLink optional params', async t => {
+  const serve = tmpServe(t, () => {})
+  await serve.ready()
+
+  const base = `http://localhost:${serve.address().port}`
+  t.is(serve.getLink('file', 'an-alias'), `${base}/file?drive=an-alias`)
+  t.is(serve.getLink('file', null, 5), `${base}/file?checkout=5`)
+  t.is(serve.getLink('file', 'an-alias', 5), `${base}/file?drive=an-alias&checkout=5`)
+})
+
 test('404 if file not found', async t => {
   t.plan(2 * 3)
 


### PR DESCRIPTION
Makes it so the user can call `getLink(...)` without having to worry about normalizing beforehand (previous code would return localhost:7000//myfile if called with path '/myfile', now returns localhost:7000/myfile)

also added tests for `getLink`