### PR TITLE
Quick closing + bugfix when error after headers set

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,28 +74,6 @@ Available `options`:
 
 The `releaseDrive` function is called with the drive `id` whenever a request finishes.
 
-You could pass your own server instance, for example:
-```js
-const ServeDrive = require('serve-drive')
-const Localdrive = require('localdrive')
-const http = require('http')
-const graceful = require('graceful-http')
-const goodbye = require('graceful-goodbye')
-
-const server = http.createServer()
-const close = graceful(server)
-const drive = new Localdrive('./my-folder')
-
-const serve = new ServeDrive({
-  getDrive: (id, filename) => drive,
-  server
-})
-await serve.ready()
-console.log('server ready')
-
-goodbye(() => close())
-```
-
 #### `serve.getLink(path, id, version)`
 
 Gets a link to the file at the given path.

--- a/index.js
+++ b/index.js
@@ -162,9 +162,11 @@ module.exports = class ServeDrive extends ReadyResource {
       safetyCatch(e)
       this.emit('request-error', e)
 
-      if (!res.headersSent) res.writeHead(500)
-      const msg = e.code || e.message
-      res.end(msg)
+      if (!res.headersSent) {
+        res.writeHead(500)
+        const msg = e.code || e.message
+        res.end(msg)
+      }
     } finally {
       await this.releaseDrive(id)
     }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = class ServeDrive extends ReadyResource {
     this.host = typeof opts.host !== 'undefined' ? opts.host : null
     this.anyPort = opts.anyPort !== false
 
-    this._connections = new Set()
+    this.connections = new Set()
     this.server = opts.server || http.createServer()
     this.server.on('request', this._onrequest.bind(this))
 
@@ -29,8 +29,8 @@ module.exports = class ServeDrive extends ReadyResource {
     await Promise.resolve() // Wait a tick, so you don't rely on server.address() being sync sometimes
 
     this.server.on('connection', c => {
-      this._connections.add(c)
-      c.on('close', () => this._connections.delete(c))
+      this.connections.add(c)
+      c.on('close', () => this.connections.delete(c))
     })
 
     try {
@@ -43,7 +43,7 @@ module.exports = class ServeDrive extends ReadyResource {
   }
 
   async _close () {
-    for (const c of this._connections) {
+    for (const c of this.connections) {
       c.destroy()
     }
     if (this.server.listening) {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = class ServeDrive extends ReadyResource {
     this.host = typeof opts.host !== 'undefined' ? opts.host : null
     this.anyPort = opts.anyPort !== false
 
+    this._connections = new Set()
     this.server = opts.server || http.createServer()
     this.server.on('request', this._onrequest.bind(this))
 
@@ -26,6 +27,11 @@ module.exports = class ServeDrive extends ReadyResource {
 
   async _open () {
     await Promise.resolve() // Wait a tick, so you don't rely on server.address() being sync sometimes
+
+    this.server.on('connection', c => {
+      this._connections.add(c)
+      c.on('close', () => this._connections.delete(c))
+    })
 
     try {
       await listen(this.server, this.port, this.host)
@@ -37,8 +43,9 @@ module.exports = class ServeDrive extends ReadyResource {
   }
 
   async _close () {
-    if (!this.opened) await this._opening.catch(safetyCatch)
-
+    for (const c of this._connections) {
+      c.destroy()
+    }
     if (this.server.listening) {
       await new Promise(resolve => this.server.close(() => resolve()))
     }
@@ -154,7 +161,8 @@ module.exports = class ServeDrive extends ReadyResource {
     } catch (e) {
       safetyCatch(e)
       this.emit('request-error', e)
-      res.writeHead(500)
+
+      if (!res.headersSent) res.writeHead(500)
       const msg = e.code || e.message
       res.end(msg)
     } finally {

--- a/test/all.js
+++ b/test/all.js
@@ -371,8 +371,11 @@ test('file server does not wait for reqs to finish before closing', async t => {
 
   await serve.close()
   await t.exception(dlProm) // Download failed
+
+  // Fails on mac if not waiting here
+  await new Promise(resolve => setTimeout(resolve, 50))
   t.is(released, 1)
 
   const msPassed = performance.now() - startTime
-  t.is(msPassed < 400, true) // (full download would have taken longer)
+  t.is(msPassed < 300, true) // (full download would have taken longer)
 })

--- a/test/all.js
+++ b/test/all.js
@@ -350,3 +350,29 @@ test('filter', async function (t) {
     custom: 2
   })
 })
+
+test('file server does not wait for reqs to finish before closing', async t => {
+  const drive = tmpHyperdrive(t)
+
+  let released = 0
+  const getDrive = () => drive
+  const releaseDrive = () => { released++ }
+
+  const manyBytes = 'a'.repeat(1000 * 1000 * 250)
+  await drive.put('Something', manyBytes)
+
+  const serve = tmpServe(t, getDrive, releaseDrive)
+  await serve.ready()
+
+  const startTime = performance.now()
+  const dlProm = request(serve, 'Something')
+  // Give some time to get started
+  await new Promise(resolve => setTimeout(resolve, 50))
+
+  await serve.close()
+  await t.exception(dlProm) // Download failed
+  t.is(released, 1)
+
+  const msPassed = performance.now() - startTime
+  t.is(msPassed < 150, true) // (full download would have taken longer)
+})

--- a/test/all.js
+++ b/test/all.js
@@ -374,5 +374,5 @@ test('file server does not wait for reqs to finish before closing', async t => {
   t.is(released, 1)
 
   const msPassed = performance.now() - startTime
-  t.is(msPassed < 150, true) // (full download would have taken longer)
+  t.is(msPassed < 400, true) // (full download would have taken longer)
 })


### PR DESCRIPTION
The bugfix handles the case were the request errors after its headers had been set but before it completes, by doing

`if (!res.headersSent) res.writeHead(500)`

Also removed an unneeded check in the close logic, as ready-resource handles that case